### PR TITLE
Grinding tools and recipe rewrites

### DIFF
--- a/WildLiving/cattails.json
+++ b/WildLiving/cattails.json
@@ -11,8 +11,7 @@
     "time": "20 minutes",
     "batch_time_factors": [ 83, 1 ],
     "autolearn": true,
-    "tools": [ [ [ "rock_quern", -1 ], [ "clay_quern", -1 ] ] ],
-    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "GRINDING", "level": 2 } ],
     "components": [ [ [ "starch_dried_flakes", 1 ] ] ],
     "charges": 15
   },

--- a/WildLiving/grinding-items-override.json
+++ b/WildLiving/grinding-items-override.json
@@ -1,0 +1,75 @@
+[
+  {
+    "id": "mortar_pestle",
+    "type": "TOOL",
+    "name": { "str": "mortar and pestle", "str_pl": "mortars and pestles" },
+    "description": "This is a simple combination of a small grindstone and a bowl-shaped stone.  Used for grinding grain, but time-consuming compared to more complex methods.",
+    "weight": "1632 g",
+    "volume": "1 L",
+    "price": 0,
+    "price_postapoc": 10,
+    "to_hit": -4,
+    "bashing": 3,
+    "material": "stone",
+    "symbol": ":",
+    "color": "light_gray",
+    "qualities": [ [ "CONTAIN", 1 ], [ "GRINDING", 1 ] ]
+  },
+  {
+    "id": "clay_quern",
+    "type": "TOOL",
+    "category": "tools",
+    "name": { "str": "clay quern" },
+    "description": "This is a simple hand-powered clay quern for grinding grain.",
+    "weight": "2264 g",
+    "volume": "1500 ml",
+    "price": 3000,
+    "price_postapoc": 10,
+    "material": "clay",
+    "symbol": ":",
+    "qualities": [ [ "GRINDING", 2 ] ],
+    "color": "brown"
+  },
+  {
+    "id": "rock_quern",
+    "type": "TOOL",
+    "name": { "str": "quern" },
+    "description": "This is a simple hand-powered stone quern for grinding grain.",
+    "weight": "3264 g",
+    "volume": "2 L",
+    "price": 0,
+    "price_postapoc": 0,
+    "to_hit": -4,
+    "bashing": 5,
+    "material": "stone",
+    "symbol": ":",
+    "qualities": [ [ "GRINDING", 2 ] ],
+    "color": "light_gray"
+  },
+  {
+    "id": "food_processor",
+    "type": "TOOL",
+    "category": "tools",
+    "name": { "str": "food processor" },
+    "description": "This is a kitchen appliance capable of slicing, chopping, shredding, grinding, pureeing and mixing.",
+    "weight": "3000 g",
+    "volume": "2 L",
+    "price": 50,
+    "price_postapoc": 250,
+    "to_hit": -1,
+    "bashing": 10,
+    "material": [ "iron" ],
+    "symbol": "%",
+    "color": "white",
+    "ammo": "battery",
+    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "qualities": [ [ "GRINDING", 3 ] ],
+    "magazines": [
+      [
+        "battery",
+        [ "medium_battery_cell", "medium_plus_battery_cell", "medium_atomic_battery_cell", "medium_disposable_cell" ]
+      ]
+    ],
+    "magazine_well": 2
+  }
+]

--- a/WildLiving/oak-harvest.json
+++ b/WildLiving/oak-harvest.json
@@ -53,7 +53,7 @@
     "autolearn": true,
     "batch_time_factors": [ 83, 3 ],
     "flags": [ "BLIND_EASY" ],
-    "tools": [ [ [ "rock_quern", -1 ], [ "clay_quern", -1 ] ] ],
+    "qualities": [ { "id": "GRINDING", "level": 2 } ],
     "components": [ [ [ "acorns_cooked", 2 ] ] ]
   },
   {
@@ -67,7 +67,7 @@
     "time": "10 minutes",
     "autolearn": true,
     "batch_time_factors": [ 83, 3 ],
-    "tools": [ [ [ "food_processor", 20 ] ] ],
+    "qualities": [ { "id": "GRINDING", "level": 3 } ],
     "components": [ [ [ "acorns_cooked", 2 ] ] ]
   },
   {
@@ -81,7 +81,7 @@
     "time": "30 minutes",
     "autolearn": true,
     "batch_time_factors": [ 83, 3 ],
-    "tools": [ [ [ "mortar_pestle", -1 ] ] ],
+    "qualities": [ { "id": "GRINDING", "level": 1 } ],
     "components": [ [ [ "acorns_cooked", 2 ] ] ]
   }
 ]

--- a/WildLiving/tool-qualities.json
+++ b/WildLiving/tool-qualities.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "tool_quality",
+    "id": "GRINDING",
+    "name": { "str": "grinding" }
+  }
+]


### PR DESCRIPTION
- Override the various grinding tools, Querns, Mortar&Pestle, and
food processor to have GRINDING qualities at appropriate levels.
- Change WL recipes requiring a grinding tool to instead use a
quality requirement.

Working concept for quality levels:
 1 - slow manual grinding, like a mortar & pestle arrangement
 2 - Larger, slightly more efficient grinding like a Quern
 3 - Something driven by a motor or gearing arrangement, Food processor

 So a reduction in effective time for each level of quality.