### PR TITLE
Small edit to modinfo.json

### DIFF
--- a/WildLiving/modinfo.json
+++ b/WildLiving/modinfo.json
@@ -4,7 +4,7 @@
     "ident": "WildLiving",
     "name": "Wild Living",
     "description": "Bring a little more life and variety to the wilds - https://github.com/LambdaSix/Wild-Living",
-    "author": [ "LambdaSix" ],
+    "authors": [ "LambdaSix" ],
     "category": "items",
     "dependencies": [ "dda" ]
   }


### PR DESCRIPTION
Upon booting original, there is an error that looks like this:

```
 DEBUG    : (json-error)
Json error: data/mods/WildLiving/modinfo.json:7:14: Invalid or misplaced field name "author" in JSON data

    "name": "Wild Living",
    "description": "Bring a little more life and variety to the wilds - https://github.com/LambdaSix/Wild-Living",
    "author":
             ^
              [ "LambdaSix" ],
    "category": "items",
    "dependencies": [ "dda" ]


 FUNCTION : void JsonObject::report_unvisited() const
 FILE     : src/json.cpp
 LINE     : 122
 VERSION  : 0.F-3
```

switching `author` to `authors` cleared the error, so I figured I'd make a pull request to fix.